### PR TITLE
feat: add support for transmission, dispersion, volume, ior and specular

### DIFF
--- a/shaders/chunks/brdf.glsl.js
+++ b/shaders/chunks/brdf.glsl.js
@@ -11,6 +11,15 @@ float D_GGX(float linearRoughness, float NoH, const vec3 h, const vec3 normalWor
   return saturateMediump(d);
 }
 
+// // The following equation(s) model the distribution of microfacet normals across the area being drawn (aka D())
+// // Implementation from "Average Irregularity Representation of a Roughened Surface for Ray Reflection" by T. S. Trowbridge, and K. P. Reitz
+// // Follows the distribution function recommended in the SIGGRAPH 2013 course notes from EPIC Games [1], Equation 3.
+// float D_GGX(float NdotH, float alphaRoughness) {
+//   float alphaRoughnessSq = alphaRoughness * alphaRoughness;
+//   float f = (NdotH * NdotH) * (alphaRoughnessSq - 1.0) + 1.0;
+//   return alphaRoughnessSq / (PI * f * f);
+// }
+
 // Estevez and Kulla 2017, "Production Friendly Microfacet Sheen BRDF"
 // https://blog.selfshadow.com/publications/s2017-shading-course/imageworks/s2017_pbs_imageworks_sheen.pdf
 // https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_sheen/README.md#sheen-distribution
@@ -58,6 +67,11 @@ float V_Neubelt(float NdotV, float NdotL, float NdotH) {
 // Used by: clearCoat e.g. in indirect.glsl.js
 float F_Schlick(float f0, float f90, float VoH) {
   return f0 + (f90 - f0) * pow(1.0 - VoH, 5.0);
+}
+
+// Used by: transmission in indirect.glsl.js
+vec3 F_Schlick(vec3 f0, vec3 f90, float VdotH) {
+  return f0 + (f90 - f0) * pow(clamp(1.0 - VdotH, 0.0, 1.0), 5.0);
 }
 
 // Diffuse:

--- a/shaders/chunks/direct.glsl.js
+++ b/shaders/chunks/direct.glsl.js
@@ -57,38 +57,6 @@ vec2 compensateStretch(vec2 uv) {
   }
 #endif
 
-// #ifdef USE_TRANSMISSION
-//   // TODO: check what's already computed (normalized normal, ndotv etc)
-//   vec3 getPunctualRadianceTransmission(
-//     vec3 normal,
-//     vec3 view,
-//     vec3 pointToLight,
-//     float alphaRoughness,
-//     vec3 f0,
-//     vec3 f90,
-//     vec3 baseColor,
-//     float ior
-//   ) {
-//       float transmissionRougness = applyIorToRoughness(alphaRoughness, ior);
-
-//       vec3 n = normalize(normal); // Outward direction of surface point
-//       vec3 v = normalize(view); // Direction from surface point to view
-//       vec3 l = normalize(pointToLight);
-//       vec3 l_mirror = normalize(l + 2.0*n*dot(-l, n));     // Mirror light reflection vector on surface
-//       vec3 h = normalize(l_mirror + v); // Halfway vector between transmission light vector and v
-
-//       // float D = D_GGX(clamp(dot(n, h), 0.0, 1.0), transmissionRougness);
-//       // vec3 F = F_Schlick(f0, f90, clamp(dot(v, h), 0.0, 1.0));
-//       // float Vis = V_GGX(clamp(dot(n, l_mirror), 0.0, 1.0), clamp(dot(n, v), 0.0, 1.0), transmissionRougness);
-//       float D = D_GGX(clamp(dot(n, h), 0.0, 1.0), transmissionRougness);
-//       vec3 F = F_Schlick(f0, f90, clamp(dot(v, h), 0.0, 1.0));
-//       float Vis = VisibilityOcclusion(clamp(dot(n, l_mirror), 0.0, 1.0), clamp(dot(n, v), 0.0, 1.0), transmissionRougness);
-
-//       // Transmission BTDF
-//       return (1.0 - F) * baseColor * D * Vis;
-//   }
-// #endif
-
 void getSurfaceShading(inout PBRData data, Light light, float illuminated) {
   vec3 N = data.normalWorld;
   vec3 V = data.viewWorld;
@@ -148,41 +116,5 @@ void getSurfaceShading(inout PBRData data, Light light, float illuminated) {
   #endif
 
   data.directColor += (color * lightColor) * (light.color.a * light.attenuation * illuminated);
-
-  // BTDF (Bidirectional Transmittance Distribution Function)
-  // #ifdef USE_TRANSMISSION
-  //   vec3 pointToLight = light.l;
-
-  //   // If the light ray travels through the geometry, use the point it exits the geometry again.
-  //   // That will change the angle to the light source, if the material refracts the light ray.
-  //   vec3 transmissionRay = getVolumeTransmissionRay(N, V, data.thickness, data.ior, uModelMatrix);
-  //   pointToLight -= transmissionRay;
-  //   L = normalize(pointToLight);
-
-  //   // vec3 intensity = getLighIntensity(light, pointToLight);
-  //   vec3 transmittedLight =
-  //     // intensity *
-  //     light.attenuation *
-  //     getPunctualRadianceTransmission(
-  //       N,
-  //       V,
-  //       L,
-  //       data.linearRoughness,
-  //       data.f0,
-  //       data.f90,
-  //       data.diffuseColor,
-  //       data.ior
-  //     );
-
-  //   transmittedLight = applyVolumeAttenuation(
-  //     transmittedLight,
-  //     length(transmissionRay),
-  //     data.attenuationColor,
-  //     data.attenuationDistance
-  //   );
-
-  //   data.transmitted += transmittedLight;
-  //   // data.transmitted += vec3(.0, 1.0, 0.0);
-  // #endif
 }
 `;

--- a/shaders/chunks/direct.glsl.js
+++ b/shaders/chunks/direct.glsl.js
@@ -98,9 +98,7 @@ void getSurfaceShading(inout PBRData data, Light light, float illuminated) {
   float NdotV = saturate(abs(dot(N, V)) + FLT_EPS);
   float NdotL = saturate(dot(N, L));
 
-  #ifndef USE_REFRACTION
   if (NdotL <= 0.0 || NdotV <= 0.0) return;
-  #endif
 
   float NdotH = saturate(dot(N, H));
   float LdotH = saturate(dot(L, H));
@@ -186,52 +184,5 @@ void getSurfaceShading(inout PBRData data, Light light, float illuminated) {
   //   data.transmitted += transmittedLight;
   //   // data.transmitted += vec3(.0, 1.0, 0.0);
   // #endif
-
-  #ifdef USE_REFRACTION
-  // data.directDiffuse = texture2D(uCaptureTexture, gl_FragCoord.xy / uViewportSize.xy).rgb;
-
-  float uIOR = 1.0;
-  vec3 IoR_Values = mix(vec3(1.0), vec3(1.14, 1.12, 1.10), uIOR);
-
-  vec3 incident = normalize(data.eyeDirWorld);
-
-  float f = F_Schlick(0.04, 1.0, abs(dot(data.viewWorld, data.normalWorld)));
-
-  vec3 refractColor = vec3(0.0);
-  // #ifdef USE_REFLECTION_PROBES
-  // refractColor.x = texture2D(uEnvMap, envMapEquirect(refract(incident, normalWorld, IoR_Values.x))).x;
-  // refractColor.y = texture2D(uEnvMap, envMapEquirect(refract(incident, normalWorld, IoR_Values.y))).y;
-  // refractColor.z = texture2D(uEnvMap, envMapEquirect(refract(incident, normalWorld, IoR_Values.z))).z;
-  // #endif
-  float refractAmount = uRefraction * 0.1;
-
-  vec3 reflectColor = vec3(0.0);
-
-  #ifdef USE_REFLECTION_PROBES
-  // reflectColor = texture2D(uReflectionMap, envMapOctahedral(reflect(-data.viewWorld, data.normalWorld), 0.0, 0.0)).rgb;
-  #endif
-
-  // vec3 IoR_Values = mix(vec3(1.0), vec3(1.14, 1.12, 1.10), uIOR);
-  float level = clamp(data.roughness + (1.0 - data.opacity), 0.0, 1.0) * 5.0; //Opacity Hack
-  vec2 uv = gl_FragCoord.xy / uViewportSize.xy;
-  vec2 refractionAspect = vec2(1.0 * uViewportSize.y/uViewportSize.x, 1.0);
-  refractColor.x = textureBicubic(uCaptureTexture, compensateStretch(uv + refractAmount * refract(incident, data.normalWorld, 1.0 / IoR_Values.x).xy), level).x;
-  refractColor.y = textureBicubic(uCaptureTexture, compensateStretch(uv + refractAmount * refract(incident, data.normalWorld, 1.0 / IoR_Values.y).xy), level).y;
-  refractColor.z = textureBicubic(uCaptureTexture, compensateStretch(uv + refractAmount * refract(incident, data.normalWorld, 1.0 / IoR_Values.z).xy), level).z;
-  // refractColor.x = texture2D(uCaptureTexture, compensateStretch(uv + refractionAspect * refractAmount * refract(incident, data.normalWorld, 1.0 / IoR_Values.x).xy)).x;
-  // refractColor.y = texture2D(uCaptureTexture, compensateStretch(uv + refractionAspect * refractAmount * refract(incident, data.normalWorld, 1.0 / IoR_Values.y).xy)).y;
-  // refractColor.z = texture2D(uCaptureTexture, compensateStretch(uv + refractionAspect * refractAmount * refract(incident, data.normalWorld, 1.0 / IoR_Values.z).xy)).z;
-
-  data.directColor *= 0.3;
-  data.directColor += data.diffuseColor * mix(refractColor, reflectColor, f);
-  // data.directColor = vec3(uViewportSize.xy, 0.0);
-  // data.directColor += refractColor;
-  // data.directColor = vec3(f);
-  // data.directColor = reflectColor;
-  // data.directColor = 0.2 + texture2D(uCaptureTexture, uv).rgb;
-  // data.directColor = vec3(uv, 1.0);
-  // data.directColor = vec3(1.0, 0.0, 1.0);
-  // data.directColor = texture2D(uCaptureTexture, uv).xyz;
-  #endif
 }
 `;

--- a/shaders/chunks/index.js
+++ b/shaders/chunks/index.js
@@ -113,6 +113,10 @@ export {
 } from "./metallic-roughness.glsl.js";
 export {
   /** @member {string} */
+  default as specular,
+} from "./specular.glsl.js";
+export {
+  /** @member {string} */
   default as specularGlossiness,
 } from "./specular-glossiness.glsl.js";
 export {

--- a/shaders/chunks/indirect.glsl.js
+++ b/shaders/chunks/indirect.glsl.js
@@ -73,8 +73,6 @@ export default /* glsl */ `
   #ifdef USE_TRANSMISSION
     // https://github.com/KhronosGroup/glTF-Sample-Viewer/blob/6bc1df9c334288fb0d91d2febfddf97ac5dfd045/source/Renderer/shaders/ibl.glsl#L78
     vec3 getTransmissionSample(vec2 fragCoord, float roughness, float ior) {
-      // float framebufferLod = log2(float(u_TransmissionFramebufferSize.x)) * applyIorToRoughness(roughness, ior);
-      // return textureLod(uCaptureTexture, fragCoord.xy, framebufferLod).rgb;
       float framebufferLod = log2(float(uViewportSize.x)) * applyIorToRoughness(roughness, ior);
       return textureBicubic(uCaptureTexture, fragCoord.xy, framebufferLod).rgb;
     }

--- a/shaders/chunks/light-directional.glsl.js
+++ b/shaders/chunks/light-directional.glsl.js
@@ -36,7 +36,7 @@ void EvaluateDirectionalLight(inout PBRData data, DirectionalLight light, sample
       )
     : 1.0;
 
-  #ifndef USE_TRANSMISSION
+  #ifndef USE_REFRACTION
   if (illuminated > 0.0) {
   #endif
     Light l;
@@ -44,7 +44,7 @@ void EvaluateDirectionalLight(inout PBRData data, DirectionalLight light, sample
     l.color = light.color;
     l.attenuation = 1.0;
     getSurfaceShading(data, l, illuminated);
-  #ifndef USE_TRANSMISSION
+  #ifndef USE_REFRACTION
   }
   #endif
 }

--- a/shaders/chunks/light-directional.glsl.js
+++ b/shaders/chunks/light-directional.glsl.js
@@ -36,17 +36,13 @@ void EvaluateDirectionalLight(inout PBRData data, DirectionalLight light, sample
       )
     : 1.0;
 
-  #ifndef USE_REFRACTION
   if (illuminated > 0.0) {
-  #endif
     Light l;
     l.l = -light.direction;
     l.color = light.color;
     l.attenuation = 1.0;
     getSurfaceShading(data, l, illuminated);
-  #ifndef USE_REFRACTION
   }
-  #endif
 }
 #endif
 `;

--- a/shaders/chunks/metallic-roughness.glsl.js
+++ b/shaders/chunks/metallic-roughness.glsl.js
@@ -2,7 +2,6 @@ export default /* glsl */ `
 #ifdef USE_METALLIC_ROUGHNESS_WORKFLOW
   uniform float uMetallic;
   uniform float uRoughness;
-  uniform float uReflectance;
 
   // Source: Google/Filament/Overview/4.8.3.3 Roughness remapping and clamping, 07/2019
   // Minimum roughness to avoid division by zerio when 1/a^2 and to limit specular aliasing

--- a/shaders/chunks/specular.glsl.js
+++ b/shaders/chunks/specular.glsl.js
@@ -1,15 +1,11 @@
 export default /* glsl */ `
-#ifdef USE_IOR
-  uniform float uIor;
+uniform float uIor;
 
-  void getIor(inout PBRData data) {
-    data.ior = uIor;
-  }
-#else
-  void getIor(inout PBRData data) {
-    data.ior = 1.5;
-  }
-#endif
+const float OUTSIDE_IOR = 1.0; // Air
+
+void getIor(inout PBRData data) {
+  data.ior = uIor;
+}
 
 #if defined(USE_SPECULAR) && !defined(USE_SPECULAR_GLOSSINESS_WORKFLOW)
   uniform float uSpecular;
@@ -58,10 +54,9 @@ export default /* glsl */ `
     // https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_specular#implementation
     // dielectricSpecularF0 = min(((ior - outside_ior) / (ior + outside_ior))^2 * specularColorFactor * specularColorTexture.rgb, float3(1.0)) * specularFactor * specularTexture.a
     // dielectricSpecularF90 = specularFactor * specularTexture.a
-    float outside_ior = 1.0;
     data.f0 = mix(
       min(
-        pow((data.ior - outside_ior) / (data.ior + outside_ior), 2.0) * specularColor,
+        pow((data.ior - OUTSIDE_IOR) / (data.ior + OUTSIDE_IOR), 2.0) * specularColor,
         vec3(1.0)
       ) * specularStrength,
       data.baseColor.rgb,
@@ -70,13 +65,13 @@ export default /* glsl */ `
     data.f90 = mix(vec3(specularStrength), vec3(1.0), data.metallic);
   }
 #else
-  uniform float uReflectance;
-
   void getSpecular(inout PBRData data) {
     // Compute F0 for both dielectric and metallic materials
-    data.f0 = 0.16 * uReflectance * uReflectance * (1.0 - data.metallic) + data.baseColor.rgb * data.metallic;
-    // TODO: is it equivalent
-    // data.f0 = mix(vec3(0.16 * uReflectance * uReflectance), data.diffuseColor.rgb, data.metallic);
+    data.f0 = mix(
+      vec3(pow((data.ior - OUTSIDE_IOR) /  (data.ior + OUTSIDE_IOR), 2.0)),
+      data.baseColor.rgb,
+      data.metallic
+    );
     data.f90 = vec3(1.0);
   }
 #endif

--- a/shaders/chunks/specular.glsl.js
+++ b/shaders/chunks/specular.glsl.js
@@ -1,0 +1,83 @@
+export default /* glsl */ `
+#ifdef USE_IOR
+  uniform float uIor;
+
+  void getIor(inout PBRData data) {
+    data.ior = uIor;
+  }
+#else
+  void getIor(inout PBRData data) {
+    data.ior = 1.5;
+  }
+#endif
+
+#if defined(USE_SPECULAR) && !defined(USE_SPECULAR_GLOSSINESS_WORKFLOW)
+  uniform float uSpecular;
+  uniform vec3 uSpecularColor;
+
+  #ifdef USE_SPECULAR_TEXTURE
+    uniform sampler2D uSpecularTexture;
+
+    #ifdef USE_SPECULAR_TEXTURE_MATRIX
+      uniform mat3 uSpecularTextureMatrix;
+    #endif
+  #endif
+
+  #ifdef USE_SPECULAR_COLOR_TEXTURE
+    uniform sampler2D uSpecularColorTexture;
+
+    #ifdef USE_SPECULAR_COLOR_TEXTURE_MATRIX
+      uniform mat3 uSpecularColorTextureMatrix;
+    #endif
+  #endif
+
+  void getSpecular(inout PBRData data) {
+    // Get specular strength and color
+    float specularStrength = uSpecular;
+    vec3 specularColor = uSpecularColor;
+
+    // Factor in textures
+    #ifdef USE_SPECULAR_TEXTURE
+      #ifdef USE_SPECULAR_TEXTURE_MATRIX
+        vec2 texCoordSpecular = getTextureCoordinates(data, SPECULAR_TEXTURE_TEX_COORD, uSpecularTextureMatrix);
+      #else
+        vec2 texCoordSpecular = getTextureCoordinates(data, SPECULAR_TEXTURE_TEX_COORD);
+      #endif
+      specularStrength *= texture2D(uSpecularTexture, texCoordSpecular).a;
+    #endif
+
+    #ifdef USE_SPECULAR_COLOR_TEXTURE
+      #ifdef USE_SPECULAR_COLOR_TEXTURE_MATRIX
+        vec2 texCoordSpecularColor = getTextureCoordinates(data, SPECULAR_COLOR_TEXTURE_TEX_COORD, uSpecularColorTextureMatrix);
+      #else
+        vec2 texCoordSpecularColor = getTextureCoordinates(data, SPECULAR_COLOR_TEXTURE_TEX_COORD);
+      #endif
+      specularColor *= texture2D(uSpecularColorTexture, texCoordSpecularColor).rgb;
+    #endif
+
+    // https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_specular#implementation
+    // dielectricSpecularF0 = min(((ior - outside_ior) / (ior + outside_ior))^2 * specularColorFactor * specularColorTexture.rgb, float3(1.0)) * specularFactor * specularTexture.a
+    // dielectricSpecularF90 = specularFactor * specularTexture.a
+    float outside_ior = 1.0;
+    data.f0 = mix(
+      min(
+        pow((data.ior - outside_ior) / (data.ior + outside_ior), 2.0) * specularColor,
+        vec3(1.0)
+      ) * specularStrength,
+      data.baseColor.rgb,
+      data.metallic
+    );
+    data.f90 = mix(vec3(specularStrength), vec3(1.0), data.metallic);
+  }
+#else
+  uniform float uReflectance;
+
+  void getSpecular(inout PBRData data) {
+    // Compute F0 for both dielectric and metallic materials
+    data.f0 = 0.16 * uReflectance * uReflectance * (1.0 - data.metallic) + data.baseColor.rgb * data.metallic;
+    // TODO: is it equivalent
+    // data.f0 = mix(vec3(0.16 * uReflectance * uReflectance), data.diffuseColor.rgb, data.metallic);
+    data.f90 = vec3(1.0);
+  }
+#endif
+`;

--- a/shaders/chunks/transmission.glsl.js
+++ b/shaders/chunks/transmission.glsl.js
@@ -1,8 +1,5 @@
 export default /* glsl */ `
-#ifdef USE_REFRACTION
-  uniform float uRefraction;
-#endif
-#if defined(USE_REFRACTION) || defined(USE_TRANSMISSION)
+#ifdef USE_TRANSMISSION
   uniform sampler2D uCaptureTexture;
 #endif
 
@@ -96,7 +93,7 @@ export default /* glsl */ `
   }
 #endif
 
-#if defined(USE_REFRACTION) || defined(USE_TRANSMISSION)
+#ifdef USE_TRANSMISSION
   // "Mipped Bicubic Texture Filtering" (https://www.shadertoy.com/view/4df3Dn)
   const float ONE_OVER_SIX = 1.0 / 6.0;
   float textureBicubicW0(float a) {

--- a/shaders/chunks/transmission.glsl.js
+++ b/shaders/chunks/transmission.glsl.js
@@ -1,31 +1,102 @@
 export default /* glsl */ `
-#ifdef USE_TRANSMISSION
-  uniform sampler2D uCaptureTexture;
+#ifdef USE_REFRACTION
   uniform float uRefraction;
-  // uniform float uTransmission;
+#endif
+#if defined(USE_REFRACTION) || defined(USE_TRANSMISSION)
+  uniform sampler2D uCaptureTexture;
+#endif
 
-  // #ifdef USE_TRANSMISSION_TEXTURE
-  //   uniform sampler2D uTransmissionTexture;
+#ifdef USE_TRANSMISSION
+  uniform float uTransmission;
+  uniform mat4 uProjectionMatrix;
 
-  //   #ifdef USE_TRANSMISSION_TEXTURE_MATRIX
-  //     uniform mat3 uTransmissionTextureMatrix;
-  //   #endif
+  uniform float uThickness;
+  uniform float uAttenuationDistance;
+  uniform vec3 uAttenuationColor;
 
-  //   void getTransmission(inout PBRData data) {
-  //     #ifdef USE_TRANSMISSION_TEXTURE_MATRIX
-  //       vec2 texCoord = getTextureCoordinates(data, TRANSMISSION_TEXTURE_TEX_COORD, uTransmissionTextureMatrix);
-  //     #else
-  //       vec2 texCoord = getTextureCoordinates(data, TRANSMISSION_TEXTURE_TEX_COORD);
-  //     #endif
+  #ifdef USE_DISPERSION
+    uniform float uDispersion;
+  #endif
 
-  //     data.transmission = uTransmission * texture2D(uTransmissionTexture, texCoord).r;
-  //   }
-  // #else
-  //   void getTransmission(inout PBRData data) {
-  //     data.transmission = uTransmission;
-  //   }
-  // #endif
+  #ifdef USE_TRANSMISSION_TEXTURE
+    uniform sampler2D uTransmissionTexture;
 
+    #ifdef USE_TRANSMISSION_TEXTURE_MATRIX
+      uniform mat3 uTransmissionTextureMatrix;
+    #endif
+
+    void getTransmission(inout PBRData data) {
+      #ifdef USE_TRANSMISSION_TEXTURE_MATRIX
+        vec2 texCoord = getTextureCoordinates(data, TRANSMISSION_TEXTURE_TEX_COORD, uTransmissionTextureMatrix);
+      #else
+        vec2 texCoord = getTextureCoordinates(data, TRANSMISSION_TEXTURE_TEX_COORD);
+      #endif
+
+      data.transmission = uTransmission * texture2D(uTransmissionTexture, texCoord).r;
+    }
+  #else
+    void getTransmission(inout PBRData data) {
+      data.transmission = uTransmission;
+    }
+  #endif
+
+  #ifdef USE_THICKNESS_TEXTURE
+    uniform sampler2D uThicknessTexture;
+
+    #ifdef USE_THICKNESS_TEXTURE_MATRIX
+      uniform mat3 uThicknessTextureMatrix;
+    #endif
+
+    void getThickness(inout PBRData data) {
+      #ifdef USE_THICKNESS_TEXTURE_MATRIX
+        vec2 texCoord = getTextureCoordinates(data, THICKNESS_TEXTURE_TEX_COORD, uThicknessTextureMatrix);
+      #else
+        vec2 texCoord = getTextureCoordinates(data, THICKNESS_TEXTURE_TEX_COORD);
+      #endif
+
+      data.thickness = uThickness * texture2D(uThicknessTexture, texCoord).g;
+    }
+  #else
+    void getThickness(inout PBRData data) {
+      data.thickness = uThickness;
+    }
+  #endif
+
+  float applyIorToRoughness(float roughness, float ior) {
+    // Scale roughness with IOR so that an IOR of 1.0 results in no microfacet refraction and
+    // an IOR of 1.5 results in the default amount of microfacet refraction.
+    return roughness * clamp(ior * 2.0 - 2.0, 0.0, 1.0);
+  }
+
+  // Compute attenuated light as it travels through a volume.
+  vec3 applyVolumeAttenuation(vec3 radiance, float transmissionDistance, vec3 attenuationColor, float attenuationDistance) {
+    if (attenuationDistance == 0.0) {
+      // Attenuation distance is +∞ (which we indicate by zero), i.e. the transmitted color is not attenuated at all.
+      return radiance;
+    } else {
+      // Compute light attenuation using Beer's law.
+      vec3 attenuationCoefficient = -log(attenuationColor) / attenuationDistance;
+      vec3 transmittance = exp(-attenuationCoefficient * transmissionDistance); // Beer's law
+      return transmittance * radiance;
+    }
+  }
+
+  vec3 getVolumeTransmissionRay(vec3 n, vec3 v, float thickness, float ior, mat4 modelMatrix) {
+    // Direction of refracted light.
+    vec3 refractionVector = refract(-v, normalize(n), 1.0 / ior);
+
+    // Compute rotation-independant scaling of the model matrix.
+    vec3 modelScale;
+    modelScale.x = length(vec3(modelMatrix[0].xyz));
+    modelScale.y = length(vec3(modelMatrix[1].xyz));
+    modelScale.z = length(vec3(modelMatrix[2].xyz));
+
+    // The thickness is specified in local space.
+    return normalize(refractionVector) * thickness * modelScale;
+  }
+#endif
+
+#if defined(USE_REFRACTION) || defined(USE_TRANSMISSION)
   // "Mipped Bicubic Texture Filtering" (https://www.shadertoy.com/view/4df3Dn)
   const float ONE_OVER_SIX = 1.0 / 6.0;
   float textureBicubicW0(float a) {

--- a/shaders/pipeline/standard.frag.js
+++ b/shaders/pipeline/standard.frag.js
@@ -305,14 +305,6 @@ void main() {
       }
     #endif
 
-    #ifdef USE_REFRACTION
-    data.indirectDiffuse  *= 0.0;//not sure how to compute it yet
-    data.indirectSpecular *= 1.0;//not sure how to compute it yet
-    // vec2 uv = gl_FragCoord.xy / uViewportSize.xy;
-    // texture2DLodEXT(uCaptureTexture, uv, level).x;
-    // data.indirectSpecular *=
-    #endif
-
     #define HOOK_FRAG_AFTER_LIGHTING
 
     color = data.emissiveColor + data.indirectDiffuse + data.indirectSpecular + data.directColor + data.transmitted;


### PR DESCRIPTION
Ref implementation is gltf sample viewer:

https://github.com/KhronosGroup/glTF-Sample-Viewer/blob/ba079f5a0cf8de9b2371b18a4644ef53eb85ba89/source/Renderer/shaders/pbr.frag#L163

https://github.com/KhronosGroup/glTF-Sample-Viewer/blob/main/source/Renderer/shaders/ibl.glsl#L78

and three.js uses it: https://github.com/mrdoob/three.js/blob/dev/src/renderers/shaders/ShaderChunk/transmission_pars_fragment.glsl.js

What need changes in pex-renderer: currently it hacks only direct reflections and discard indirect.

What this PR does:

- transmission in direct and indirect chunks
- add volume support (thickness, attenuation distance and attenuation color)
- add ior support (default: 1.5 air following gltf spec in pex-renderer) + remove reflectance
- add specular: replaces old spec/gloss workflow and give control for f0/f90
- add dispersion (basically chromatic abberation in transmitted)

Changes from gltf implementation:

- use PBRData when possible
- add uniforms
- use textureBicubicSample
- mix in EvaluateLightProbe and in getSurfaceShading like filament does
- not using the [BTDF extra term](https://github.com/KhronosGroup/glTF-Sample-Viewer/blob/ba079f5a0cf8de9b2371b18a4644ef53eb85ba89/source/Renderer/shaders/pbr.frag#L237-L253) as not sure how it works

Notes:
- three.js has transmissionAlpha for better mixing with transparent background (?)